### PR TITLE
Offline Caching

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -79,4 +79,7 @@ dependencies {
     // for google map
     implementation("com.google.android.gms:play-services-maps:latest_version")
 
+    //google JSON
+    implementation(libs.gson);
+
 }

--- a/code/app/src/main/java/com/example/projectapp/HistoryActivity.java
+++ b/code/app/src/main/java/com/example/projectapp/HistoryActivity.java
@@ -429,6 +429,8 @@ MoodEventDetailsAndEditingFragment.EditMoodEventListener, MoodEventDeleteFragmen
                     moodEventAdapter = new MoodEventArrayAdapter(getApplicationContext(), displayedMoodEvents, HistoryActivity.this);
                     moodEventList.setAdapter(moodEventAdapter);
                     moodEventAdapter.notifyDataSetChanged();
+                    filter_spinner_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                    filter_spinner.setAdapter(filter_spinner_adapter);
                 }
 
                 @Override

--- a/code/app/src/main/java/com/example/projectapp/MoodEventActivity.java
+++ b/code/app/src/main/java/com/example/projectapp/MoodEventActivity.java
@@ -12,6 +12,8 @@
 
 package com.example.projectapp;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import static androidx.activity.result.ActivityResultCallerKt.registerForActivityResult;
 
@@ -21,6 +23,8 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.location.Location;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
@@ -48,12 +52,17 @@ import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FieldValue;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 public class MoodEventActivity extends AppCompatActivity {
@@ -80,6 +89,10 @@ public class MoodEventActivity extends AppCompatActivity {
     private FirebaseStorage storage;
     private StorageReference storageRef;
 
+    //offline sync resources
+    private static final String PENDING_EVENTS_PREFS = "PendingMoodEvents";
+    private static final String KEY_PENDING_EVENTS = "pendingMoodEvents";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -95,13 +108,22 @@ public class MoodEventActivity extends AppCompatActivity {
         // Hide the ImageView by default so there's no empty space if no photo is selected.
         imageView.setVisibility(View.GONE);
         configureVisibilityToggle();
+        disableOrEnableLocationUpload(isNetworkAvailable());
         configureLocationButton();
         configureViewMapButton();
         configureAddEventButton();
         configurePhotoLaunchers();
         configureSpinnerAdapters();
+        disableOrEnablePhotoUpload(isNetworkAvailable());
         configureUploadPhotoButton();
         configureBottomNav();
+    }
+
+    /*helper to detect if user is connected to the internet*/
+    private boolean isNetworkAvailable() {
+        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        return activeNetwork != null && activeNetwork.isConnected();
     }
 
     private void bindUIElements() {
@@ -244,11 +266,64 @@ public class MoodEventActivity extends AppCompatActivity {
         });
     }
 
+    /*finished activity and goes to home screen*/
+    private void goToHome() {
+        Intent intent = new Intent(getApplicationContext(), HomeActivity.class);
+        startActivity(intent);
+        finish();
+    }
+
+    //helper that saves added mood event to sharedpreferences if the user is offline
+    private void savePendingMoodEvent(MoodEvent event) {
+        SharedPreferences prefs = getSharedPreferences(PENDING_EVENTS_PREFS, MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        Gson gson = new Gson();
+
+        //load the current mood events to be synced
+        String json = prefs.getString(KEY_PENDING_EVENTS, null);
+        Type type = new TypeToken<List<MoodEvent>>(){}.getType();
+        List<MoodEvent> pendingList = json != null ? gson.fromJson(json, type) : new ArrayList<>();
+
+        pendingList.add(event);
+        editor.putString(KEY_PENDING_EVENTS, gson.toJson(pendingList));
+        editor.apply();
+    }
+
+
+    //function that disa
+    private void disableOrEnablePhotoUpload(boolean online) {
+        if (online) {
+            buttonUploadPhoto.setEnabled(true);
+            buttonUploadPhoto.setAlpha(1.0f);
+        } else {
+            buttonUploadPhoto.setEnabled(false);
+            buttonUploadPhoto.setAlpha(0.5f);
+        }
+    }
+
+    private void disableOrEnableLocationUpload(boolean online) {
+        if (online) {
+            buttonAddLocation.setEnabled(true);
+            buttonAddLocation.setAlpha(1.0f);
+        } else {
+            buttonAddLocation.setEnabled(false);
+            buttonAddLocation.setAlpha(0.5f);
+        }
+    }
+
     /**
      * Helper method that adds the event to the user's profile via FirebaseSync
      * and then navigates back to HomeActivity.
      */
     private void addEventAndFinish(MoodEvent event) {
+
+        if (!isNetworkAvailable()) {
+            savePendingMoodEvent(event);
+            Toast.makeText(this, "No internet. Event will sync when reconnected.", Toast.LENGTH_SHORT).show();
+            goToHome();
+            return;
+        }
+
         FirebaseSync fb = FirebaseSync.getInstance();
         fb.fetchUserProfileObject(new UserProfileCallback() {
             @Override
@@ -257,9 +332,7 @@ public class MoodEventActivity extends AppCompatActivity {
                 Toast.makeText(MoodEventActivity.this,
                         "Mood Event Added!",
                         Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(getApplicationContext(), HomeActivity.class);
-                startActivity(intent);
-                finish();
+                goToHome();
             }
 
             @Override
@@ -485,5 +558,12 @@ public class MoodEventActivity extends AppCompatActivity {
                     Toast.LENGTH_SHORT).show();
             return null;
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        disableOrEnableLocationUpload(isNetworkAvailable());
+        disableOrEnablePhotoUpload(isNetworkAvailable());
     }
 }


### PR DESCRIPTION
Added ability for mood events to be edited/deleted/added offline and have changes sync when connection is re-established. Also made it so filters in the HistoryActivity event are cleared after an edit (deletion or change) occurs.

Heres some tips, all offline changes are synced in the HistoryActivity. Therefore, in order for a user to sync their changes they must navigate to the HistoryActivity for the changes to be synced. This is also true for Adding a MoodEvent while offline, however for MoodEvents, if connection is re-established while the user is on the home page they will be notified that offline changes are ready to sync, the user must then navigate to the HistoryActivity in order for the changes to be synced and it may take a bit for that to occur (~ 1 second or so). Also while the user is offline they cannot add a location or picture to the MoodEvent to be added.